### PR TITLE
fix an issues when plot.tag of theme is NULL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,4 +18,4 @@ Suggests:
 URL: https://github.com/YuLab-SMU/aplot
 License: Artistic-2.0
 Encoding: UTF-8
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/R/plot-list.R
+++ b/R/plot-list.R
@@ -83,7 +83,9 @@ plot_list <- function(..., gglist = NULL,
 
     if (!is.null(tag_levels) || !is.null(labels)) {
         pt <- p$theme$plot.tag
-        if (is.null(pt)) pt <- list()
+        if (is.null(pt)){
+            pt <- ggplot2::element_text()
+        }
         pt <- modifyList(pt, list(size = tag_size))
         p <- p + plot_annotation(tag_levels=tag_levels) &
             theme(plot.tag = pt)


### PR DESCRIPTION
when the `plot.tag` of `first` plot of `plot_list` is NULL, the original `plot_list` will generate error

The related issue is [this](https://github.com/YuLab-SMU/treedata-book/issues/58)

This is because the `plot.tag` of `theme` must be a `element_text` class.

# Example

```
> library(ggtree)
ggtree v3.3.1  For help: https://yulab-smu.top/treedata-book/

If you use ggtree in published research, please cite the most appropriate paper(s):

1. Guangchuang Yu. Using ggtree to visualize data on tree-like structures. Current Protocols in Bioinformatics. 2020, 69:e96. doi:10.1002/cpbi.96
2. Guangchuang Yu, Tommy Tsan-Yuk Lam, Huachen Zhu, Yi Guan. Two methods for mapping and visualizing associated data on phylogeny using ggtree. Molecular Biology and Evolution. 2018, 35(12):3041-3043. doi:10.1093/molbev/msy194
3. Guangchuang Yu, David Smith, Huachen Zhu, Yi Guan, Tommy Tsan-Yuk Lam. ggtree: an R package for visualization and annotation of phylogenetic trees with their covariates and other associated data. Methods in Ecology and Evolution. 2017, 8(1):28-36. doi:10.1111/2041-210X.12628


> library(ggplot2)
> x <- rtree(20)
> p1 <- ggtree(x) + geom_tiplab() + hexpand(.3)
> p2 <- ggplot(iris, aes(Sepal.Width, Petal.Width)) +
      geom_point() +
      hexpand(.2, direction = -1) +
      vexpand(.2)
> aplot::plot_list(p1, p2, tag_levels="A", widths=c(.6, .4))
```

![xx](https://user-images.githubusercontent.com/17870644/148335877-df885e5d-a5fe-4760-aa34-188fff71d2ab.PNG)
