### PR TITLE
use original scale when sub plot is not ggtree

### DIFF
--- a/R/axis.R
+++ b/R/axis.R
@@ -55,13 +55,23 @@ ggplot_add.axisAlign <- function(object, plot, object_name) {
     ## expand_limits <- object$expand_limits
     ## limits[1] <- limits[1] + (limits[1] * expand_limits[1]) - expand_limits[2]
     ## limits[2] <- limits[2] + (limits[2] * expand_limits[3]) + expand_limits[4]
-
+    gb <- ggplot2::ggplot_build(plot)
     if (is.numeric(limits)) {
-        lim_x <- scale_x_continuous(limits=limits, expand=c(0,0))
-        lim_y <- scale_y_continuous(limits = limits, expand = c(0, 0))
+        if (inherits(plot, 'ggtree')){
+            lim_x <- scale_x_continuous(limits=limits, expand=c(0, 0))
+            lim_y <- scale_y_continuous(limits = limits, expand = c(0, 0))
+        }else{
+            lim_x <- set_scale_limits(gb$layout$panel_scales_x[[1]], limits=limits, expand=c(0, 0))
+            lim_y <- set_scale_limits(gb$layout$panel_scales_y[[1]], limits=limits, expand=c(0, 0))
+        }
     } else {
-        lim_x <- scale_x_discrete(limits=limits, expand = c(0, 0.6))
-        lim_y <- scale_y_discrete(limits = limits, expand = c(0, 0.6))
+        if (inherits(plot, 'ggtree')){
+            lim_x <- scale_x_discrete(limits=limits, expand = c(0, 0.6))
+            lim_y <- scale_y_discrete(limits = limits, expand = c(0, 0.6))
+        }else{
+            lim_x <- set_scale_limits(gb$layout$panel_scales_x[[1]], limits=limits, expand = c(0, .6))
+            lim_y <- set_scale_limits(gb$layout$panel_scales_y[[1]], limits=limits, expand = c(0, .6))
+        }
     }
 
     if (object$axis == 'x') {
@@ -69,6 +79,9 @@ ggplot_add.axisAlign <- function(object, plot, object_name) {
         if (is(plot$coordinates, "CoordFlip")) {
             message("the plot was flipped and the x limits will be applied to y-axis")
             scale_lim <- lim_y
+            if (!inherits(plot, 'ggtree')){
+                scale_lim <- switch_position(scale_lim)
+            }
         } else {
             scale_lim <- lim_x
         }
@@ -92,10 +105,28 @@ ggplot_add.axisAlign <- function(object, plot, object_name) {
         if (is(plot$coordinates, "CoordFlip")) {
             message("the plot was flipped and the y limits will be applied to x-axis")
             scale_lim <- lim_x
+            if (!inherits(plot, 'ggtree')){
+                scale_lim <- switch_position(scale_lim)
+            }
         } else {
             scale_lim <- lim_y
         }
         ## }
     }
     ggplot_add(scale_lim, plot, object_name)
+}
+
+set_scale_limits <- function(scales, limits, expand){
+    scales$limits <- limits
+    scales$expand <- expand
+    return(scales)
+}
+
+switch_position <- function(scales){
+    scales$position <- switch(scales$position, 
+                              bottom='left', 
+                              top='right', 
+                              left='bottom', 
+                              right='top')
+    return(scales)
 }


### PR DESCRIPTION
when subplot is no `ggtree` object, the position of the axis label can not be adjusted.

```
library(ggplot2)
library(tibble)
library(aplot)
set.seed(20200618)
gmat <- expand.grid(x = letters[1:10], y = letters[1:10])
gmat$v <- rexp(100, rate=.1)
gbar <- tibble(x = letters[1:10], y = round(runif(10) * 100,1))
pmat <- ggplot(gmat, aes(x,y, fill=v)) + geom_tile()
pbar <- ggplot(gbar, aes(x, y)) + geom_col()
pbar + scale_x_discrete(position='top') + coord_flip() -> pbar1
pmat %>% insert_top(pbar + scale_x_discrete(position='top'))
```
![xx](https://user-images.githubusercontent.com/17870644/202402561-06409b03-aab2-4b40-aba3-8b8a9656bcc1.PNG)

```
> pmat %>% insert_right(pbar1)
```
![捕获](https://user-images.githubusercontent.com/17870644/202402587-a072837f-f101-4132-b45a-d134c0e7cb9b.PNG)

This `pr` fix the issue

```
pmat %>% insert_top(pbar + scale_x_discrete(position='top'))
```
![xx](https://user-images.githubusercontent.com/17870644/202413485-d341d3ca-921b-4468-94d6-39c2a61ba2fd.PNG)

```
> pmat %>% insert_right(pbar1)
```
![捕获](https://user-images.githubusercontent.com/17870644/202413591-4a9892a8-2b4e-4dac-a27b-89c0c6829624.PNG)


