### PR TITLE
control the space of subplots

### DIFF
--- a/R/aplot.R
+++ b/R/aplot.R
@@ -75,8 +75,12 @@ as.patchwork <- function(x,
     idx[is.na(idx)] <- x$n + 1 
     x$plotlist[[x$n+1]] <- ggplot() + theme_void() # plot_spacer()
     plotlist <- x$plotlist[idx]
-    
-    pp <- plotlist[[1]] + theme_no_margin()
+    space <- getOption(x="space.between.plots", default=0)
+    theme.first <- theme_no_margin()
+    if (!space==0){
+        theme.first$plot.margin <- do.call(ggplot2::margin, c(rep(list(space), 4), unit='mm'))
+    }
+    pp <- plotlist[[1]] + theme.first
     for (i in 2:length(plotlist)) {
         pp <- pp + (plotlist[[i]] + theme_no_margin())
     }


### PR DESCRIPTION
+ introduce `options(space.between.plots=XXX)` to control the space between the subplots.

```
> library(ggplot2)
Need help getting started? Try the R Graphics Cookbook:
https://r-graphics.org

> library(aplot)

> p <- ggplot(mtcars, aes(mpg, disp)) + geom_point()

> p2 <- ggplot(mtcars, aes(mpg)) +
      geom_density(fill='steelblue', alpha=.5) +
          ggfun::theme_noxaxis()

> p3 <- ggplot(mtcars, aes(x=1, y=disp)) +
      geom_boxplot(fill='firebrick', alpha=.5) +
      theme_void()

> ap <- p %>%
      insert_top(p2, height=.3) %>%
      insert_right(p3, width=.1)

> ap[2, 1] <- ap[2, 1] + theme_bw()

> ap[2, 1] <- ap[2, 1] +
              aes(color = as.factor(am)) +
              scale_color_manual(values = c('steelblue', 'darkgreen'))

> ap[1, 1] <- ap[1, 1] + theme(axis.line.x.bottom=element_line())

> ap[1,1] <- ap[1,1] + xlab(NULL)
> options(space.between.plots=5)
> ap
```
![捕获](https://github.com/YuLab-SMU/aplot/assets/17870644/dc8a77b2-4fb7-4ea0-9eab-ceef2573caf2)
