### PR TITLE
CoordFixed is missing in new ggplot2 (4.0.0)

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -20,7 +20,7 @@ is.coord_flip <- function(p) {
 }
 
 is.coord_fixed <- function(p){
-    inherits(p, "gg") && inherits(p$coordinates, "CoordFixed")
+    inherits(p, "gg") && !is.null(p$coordinates$ratio)
 }
 
 #' @importFrom ggplot2 coord_fixed


### PR DESCRIPTION
```
> library(ggplot2)
> coord_fixed() |> class()
[1] "CoordCartesian" "Coord"          "ggproto"        "gg"
> inherits(coord_fixed(), 'CoordFixed')
[1] FALSE
>
```

related PR https://github.com/YuLab-SMU/aplot/pull/45 and issue https://github.com/YuLab-SMU/aplot/issues/41